### PR TITLE
Add Download plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,24 @@ var ezs = require('ezs');
 ezs.use(require('ezs-istex'));
 ```
 
-
 ## Statements
 
-TODO
+### ISTEXDownload
+
+*Come after : ISTEXRequest*
+
+This plugin will download the selected file contained in the result of ISTEX API.
+
+```js
+.pipe(ezs('ISTEXDownload', {
+  criteria: {                       // Criteria
+    "extension": "txt",
+    "original": false,
+    "mimetype": "text/plain"
+  },
+  out: "/my/path/",                 // Output path
+  key: "fulltext"                   // Which key contain the data :
+}))                                 // - fulltext (.pdf, .txt, .tei, ...) => key: "fulltext"
+                                    // - metadata (.mods, .xml, ...)      => key: "metadata"
+                                    // - enrichments (.tei, ...)          => key: "unitex" / "teeft" / "multicat" / "refBibs" / "nb" / "abesAuthors" / "abesSubjects"
+```

--- a/examples/corpus-to-download
+++ b/examples/corpus-to-download
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const ezs = require('ezs');
+ezs.use(require('ezs-basics'));
+ezs.use(require('..'));
+
+const output = 'id'
+             + ',fulltext,enrichments,metadata';
+
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+process.stdin
+  .pipe(ezs('stringify'))
+  // .pipe(ezs('concat'))
+  .pipe(ezs('ISTEXCorpus'))
+  .pipe(ezs('ISTEXQuery', { params: { output } }))
+  .pipe(ezs('ISTEXHarvest'))
+  .pipe(ezs('ISTEXRequest'))
+  .pipe(ezs('ISTEXDownload', {
+    criteria: {
+      "extension": "tei",
+      "original": false,
+      "mimetype": "application/tei+xml"
+    },
+    out: "./",
+    key: "nb"
+  }))
+  .pipe(ezs('jsonify'))
+  .pipe(process.stdout)
+;
+

--- a/examples/corpus/small.corpus
+++ b/examples/corpus/small.corpus
@@ -1,0 +1,13 @@
+#
+# Exemple de fichier coprus
+# 
+title        Exemple de corpus ISTEX
+author       Nicolas
+publisher    CNRS
+description  Ensemble de requetes pour montrer comment consituer un corpus ISTEX chargeable dans lodex
+licence      CC-By
+versionInfo  1
+
+[ISTEX]
+id F6CB7249E90BD96D5F7E3C4E80CC1C3FEE4FF483
+id D8243AB8AF68D5226C3990E465CEE399E012663F

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
   ISTEXRequest: require('./lib/request.js'),
   ISTEXHits: require('./lib/hits.js'),
   ISTEXMods: require('./lib/mods.js'),
+  ISTEXDownload: require('./lib/download.js'),
   ISTEXParseXML: require('./lib/parse-xml.js'),
   ISTEXScroll: require('./lib/scroll.js'),
   ISTEXTriplify: require('./lib/triplify.js'),

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,0 +1,59 @@
+const path = require('path'),
+  fs = require('fs'),
+  request = require('request'),
+  async = require('async');
+/*
+ * Ce plugin récupère les hits (résultats de la requête à l'API ISTEX), puis télécharge les fichiers selon les critères demandé.  
+ */
+module.exports = function(data, feed) {
+  let self = this;
+  if (self.isLast()) {
+    feed.close();
+  } else {
+    let handle = self.getParam('path', data.ISTEX);
+    if (!(handle && handle.hits)) return feed.send(data);
+    async.eachSeries(handle.hits, function(hit, next) {
+      let files = (self.getParam("key") === "fulltext" || self.getParam("key") === "metadata") ? hit[self.getParam("key")] : hit.enrichments[self.getParam("key")];
+      if (!files) return next();
+      let file = selectFile(files, self.getParam("criteria"));
+      if (!(file && file.uri)) return next();
+      request(file.uri, function(error, response, body) {
+        if (error) next(error);
+        if (response.statusCode.toString()[0] !== '2') return next(response); // Si erreur http (code différent de 2XX, on la remonte
+        var filePath = path.join(self.getParam("out"), hit.id + '.' + self.getParam("criteria").extension); // Calcul du chemin complet du fichier téléchargé
+        fs.writeFile(filePath, body, function(err) {
+          if (err) return next(err);
+          hit.filename = filePath;
+          next();
+        });
+      });
+    }, function(err) {
+      if (err) {
+        throw err;
+      }
+      feed.send(data);
+    });
+  }
+};
+
+/**
+ * Retourne le premier objet du Tableau de fichier respectant tous les critères spécifiées
+ * Exemple : Je souhaite récupérer le fichier txt généré par LoadIstex
+ *   files = docObject.fulltext (paramètre du docObject contenant les infos liées au fulltext)
+ *   criteria = { mime: 'text/plain', original: false }, --> ficher txt généré par LoadIstex
+ * @param {array} files Tableau d'objet représentant un ensemble de fichier (ex : jsonLine.metadata || jsonLine.fulltext)
+ * @param {object} criteria Objet regroupant les critères du document recherché
+ * @return {object} L'objet correspondant ou null
+ */
+function selectFile(files, criteria) {
+  var keys = Object.keys(criteria);
+  for (var i = 0; i < files.length; i++) {
+    var found = true;
+    for (var j = 0; j < keys.length; j++) {
+      found &= (criteria[keys[j]] instanceof RegExp) ? criteria[keys[j]].test(files[i][keys[j]]) : (files[i][keys[j]] === criteria[keys[j]]);
+      if (!found) break;
+    }
+    if (found) return files[i];
+  }
+  return null;
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/touv/node-ezs-istex#readme",
   "dependencies": {
+    "async": "^2.4.1",
     "clone": "2.1.1",
     "co": "^4.6.0",
     "dot-prop": "4.1.1",


### PR DESCRIPTION
Le plugin se charge de télécharger le fichier correspondant au critères renseignés.

Commande pour lancer le script qui implémente la fonctionnalité :

cd examples/
cat corpus/small.corpus | ./corpus-to-download