### PR TITLE
Fix ISTEXUniq

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
     "extends": "airbnb",
     "rules": {
         "indent": ["error", 4],
-        "max-len": ["error", {"code": 80, "tabWidth": 4, "ignoreUrls": true}],
+        "max-len": ["error", {"code": 120, "tabWidth": 4, "ignoreUrls": true}],
         "no-console": ["error", { "allow": ["warn"] }],
         "no-underscore-dangle": ["error", { "allow": ["_id", "_error"] }],
         "import/no-extraneous-dependencies": "off",

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -1,5 +1,5 @@
 import { equals } from 'ramda';
-import { getTriple } from './utils';
+import { getSubject } from './utils';
 
 let triples;
 let previous;
@@ -8,7 +8,7 @@ function ISTEXUniq(data, feed) {
     function writeFilteredTriples() {
         triples.reduce((alreadySeen, t) => {
             if (!alreadySeen.find(equals(t))) {
-                feed.write(`${t.subject} ${t.verb} ${t.complement} .\n`);
+                feed.write(t);
             }
             alreadySeen.push(t);
             return alreadySeen;
@@ -20,7 +20,7 @@ function ISTEXUniq(data, feed) {
         return feed.close();
     }
 
-    const [subject, verb, complement] = getTriple(data);
+    const subject = getSubject(data);
 
     if (this.isFirst()) {
         triples = [];
@@ -33,7 +33,11 @@ function ISTEXUniq(data, feed) {
         previous = subject;
     }
 
-    triples.push({ subject, verb, complement });
+    let triple = data;
+    if (!triple.endsWith('\n')) {
+        triple += '\n';
+    }
+    triples.push(triple);
     feed.end();
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,21 +24,8 @@ export function newValue(value, path, data) {
     return out;
 }
 
-export function getTriple(line) {
-    let [subject, verb, complement] = line.split('> ', 3);
+export function getSubject(line) {
+    let [subject] = line.split('>', 1);
     subject += '>';
-    verb += '>';
-    if (complement === '.\n' || complement === '.') {
-        // In the case of a verb badly parsed (ex: <uri1> a <uri2>)
-        [verb, complement] = verb.split(' ', 2);
-    } else if (!complement.endsWith('" .\n') && !complement.endsWith('" .')) {
-        // In the case of an URI, split removed the end of the complement
-        complement += '>';
-    } else if (complement.endsWith('\n')) {
-        // In the normal case
-        complement = complement.slice(0, -3); // Remove " .\n"
-    } else {
-        complement = complement.slice(0, -2); // Remove " ."
-    }
-    return [subject, verb, complement];
+    return subject;
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -306,7 +306,6 @@ describe('ISTEXTriplify', () => {
             });
     }).timeout(5000);
 
-
     it('should yield as many triples as properties', (done) => {
         const result = [];
         from([
@@ -817,6 +816,24 @@ describe('ISTEXUniq', () => {
                 });
         },
     );
+
+    it('should not mess up > character in literal', (done) => {
+        let result = [];
+        from([
+            '<subject1> <verb> "Another Rigvedic Genitive Singular in -E > -AS?" .',
+        ])
+            .pipe(ezs('ISTEXUniq'))
+            // .pipe(ezs('debug'))
+            .on('data', (chunk) => {
+                result = result.concat(chunk);
+            })
+            .on('end', () => {
+                assert.equal(result.length, 1);
+                assert.equal(result[0],
+                    '<subject1> <verb> "Another Rigvedic Genitive Singular in -E > -AS?" .\n');
+                done();
+            });
+    });
 });
 
 describe('ISTEXParseDotCorpus', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,70 +1,56 @@
 const assert = require('assert');
 
-const { getTriple } = require('../lib/utils');
+const { getSubject } = require('../lib/utils');
 
 describe('utils', () => {
-    describe('getTriple', () => {
+    describe('getSubject', () => {
         it('should parse URIs triple without carrier', () => {
-            const [subject, verb, complement] = getTriple(
+            const subject = getSubject(
                 '<subject> <verb> <complement> .',
             );
             assert.equal(subject, '<subject>');
-            assert.equal(verb, '<verb>');
-            assert.equal(complement, '<complement>');
         });
 
         it('should parse URIs triple with carrier', () => {
-            const [subject, verb, complement] = getTriple(
+            const subject = getSubject(
                 '<subject> <verb> <complement> .\n',
             );
             assert.equal(subject, '<subject>');
-            assert.equal(verb, '<verb>');
-            assert.equal(complement, '<complement>');
         });
 
         it('should parse triple with "a" without carrier', () => {
-            const [subject, verb, complement] = getTriple(
+            const subject = getSubject(
                 '<subject> a <type> .',
             );
             assert.equal(subject, '<subject>');
-            assert.equal(verb, 'a');
-            assert.equal(complement, '<type>');
         });
 
         it('should parse triple with "a" with carrier', () => {
-            const [subject, verb, complement] = getTriple(
+            const subject = getSubject(
                 '<subject> a <type> .\n',
             );
             assert.equal(subject, '<subject>');
-            assert.equal(verb, 'a');
-            assert.equal(complement, '<type>');
         });
 
         it('should parse triple with a litteral with carrier', () => {
-            const [subject, verb, complement] = getTriple(
+            const subject = getSubject(
                 '<subject> <verb> "complement" .\n',
             );
             assert.equal(subject, '<subject>');
-            assert.equal(verb, '<verb>');
-            assert.equal(complement, '"complement"');
         });
 
         it('should parse triple with a litteral without carrier', () => {
-            const [subject, verb, complement] = getTriple(
+            const subject = getSubject(
                 '<subject> <verb> "complement" .',
             );
             assert.equal(subject, '<subject>');
-            assert.equal(verb, '<verb>');
-            assert.equal(complement, '"complement"');
         });
 
         it('should parse literals containing >', () => {
-            const [subject, verb, complement] = getTriple(
+            const subject = getSubject(
                 '<subject> <verb> "comp > lement" .',
             );
             assert.equal(subject, '<subject>');
-            assert.equal(verb, '<verb>');
-            assert.equal(complement, '"comp > lement"');
         });
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -57,5 +57,14 @@ describe('utils', () => {
             assert.equal(verb, '<verb>');
             assert.equal(complement, '"complement"');
         });
+
+        it('should parse literals containing >', () => {
+            const [subject, verb, complement] = getTriple(
+                '<subject> <verb> "comp > lement" .',
+            );
+            assert.equal(subject, '<subject>');
+            assert.equal(verb, '<verb>');
+            assert.equal(complement, '"comp > lement"');
+        });
     });
 });


### PR DESCRIPTION
When a title has `>` character, the literal is not closed, and the NQuads syntax is broken.

Ex:

```json
{
  "author": [
    {
      "name": "Migron"
    }
  ],
  "arkIstex": "ark:/67375/JKT-KRR0G95J-2",
  "title": "Another Rigvedic Genitive Singular in -E > -AS?",
  "host": {
    "title": "Indo-Iranian Journal",
    "language": [
      "unknown"
    ],
    "issn": [
      "0019-7246"
    ],
    "eissn": [
      "1572-8536"
    ],
    "volume": "42",
    "issue": "1",
    "pages": {
      "first": "33",
      "last": "34"
    },
    "genre": [
      "journal"
    ]
  },
  "publicationDate": "1999",
  "doi": [
    "10.1163/000000099124993013"
  ],
  "id": "AF193C709A0284C551ADEEB5C2191C9212C53CB7",
}
```

gives, among other triples:

```nq
<https://api.istex.fr/ark:/67375/JKT-KRR0G95J-2> <http://purl.org/dc/terms/title> "Another Rigvedic Genitive Singular in -E > .
```
which is clearly syntactically broken (at the end).